### PR TITLE
Fix deprecation warnings for implicit nullable parameters

### DIFF
--- a/src/Limit.php
+++ b/src/Limit.php
@@ -69,7 +69,7 @@ class Limit
     /**
      * @param (callable(): mixed)|null $responseHandler
      */
-    final public function __construct(int $allow, float $threshold = 1, callable $responseHandler = null)
+    final public function __construct(int $allow, float $threshold = 1, ?callable $responseHandler = null)
     {
         $this->allow = $allow;
         $this->threshold = $threshold;
@@ -123,7 +123,7 @@ class Limit
     /**
      * Set the limit as exceeded
      */
-    public function exceeded(int $releaseInSeconds = null): void
+    public function exceeded(?int $releaseInSeconds = null): void
     {
         $this->exceeded = true;
 


### PR DESCRIPTION
This Pr fixes Deprecation warnings for implicit nullable parameters


`DEPRECATED  Saloon\RateLimitPlugin\Limit::__construct(): Implicitly marking parameter $responseHandler as nullable is deprecated, the explicit nullable type must be used instead in vendor/saloonphp/rate-limit-plugin/src/Limit.php on line 72.`


`DEPRECATED  Saloon\RateLimitPlugin\Limit::exceeded(): Implicitly marking parameter $releaseInSeconds as nullable is deprecated, the explicit nullable type must be used instead in vendor/saloonphp/rate-limit-plugin/src/Limit.php on line 126.`

Fixes #15 