### PR TITLE
Fix the bug when resetting the limit based on the response handler

### DIFF
--- a/src/Exceptions/RateLimitReachedException.php
+++ b/src/Exceptions/RateLimitReachedException.php
@@ -12,7 +12,7 @@ class RateLimitReachedException extends SaloonException
     /**
      * Constructor
      */
-    public function __construct(readonly protected Limit $limit)
+    public function __construct(protected readonly Limit $limit)
     {
         parent::__construct(sprintf('Request Rate Limit Reached (Name: %s)', $this->limit->getName()));
     }

--- a/src/Limit.php
+++ b/src/Limit.php
@@ -349,7 +349,13 @@ class Limit
         // reset the limit completely and hit once.
 
         if ($this->getRemainingSeconds() < 1) {
-            $this->resetLimit()->hit($resetHits);
+            // When using the fromResponse limiter, we don't need to update the hit
+            // as we only update the hit when the detect the too many attempts
+            if ($this->usesResponse()) {
+                $this->resetLimit();
+            } else {
+                $this->resetLimit()->hit($resetHits);
+            }
         }
 
         $data = [

--- a/src/Stores/FileStore.php
+++ b/src/Stores/FileStore.php
@@ -21,7 +21,7 @@ class FileStore implements RateLimitStore
      * @throws \Saloon\Exceptions\DirectoryNotFoundException
      * @throws \Saloon\Exceptions\UnableToCreateDirectoryException
      */
-    public function __construct(readonly protected string $directory)
+    public function __construct(protected readonly string $directory)
     {
         $this->storage = new Storage($this->directory, false);
     }

--- a/src/Stores/PsrStore.php
+++ b/src/Stores/PsrStore.php
@@ -12,7 +12,7 @@ class PsrStore implements RateLimitStore
     /**
      * Constructor
      */
-    public function __construct(readonly protected CacheInterface $cache)
+    public function __construct(protected readonly CacheInterface $cache)
     {
         //
     }

--- a/src/Stores/RedisStore.php
+++ b/src/Stores/RedisStore.php
@@ -12,7 +12,7 @@ class RedisStore implements RateLimitStore
     /**
      * Constructor
      */
-    public function __construct(readonly protected Redis $redis)
+    public function __construct(protected readonly Redis $redis)
     {
         //
     }


### PR DESCRIPTION
### Problem
Response-based limiters (created with `Limit::custom()`) were incrementing hit counters during resets, causing inaccurate rate limiting.
### Fix
Skip hit increment for response-based limiters during reset operations.

@Sammyjo20 Could you please review this fix? This bug prevents us from using the response-based limiter.