### PR TITLE
Check Cache for Existing Data

### DIFF
--- a/src/Stores/LaravelCacheStore.php
+++ b/src/Stores/LaravelCacheStore.php
@@ -32,6 +32,17 @@ class LaravelCacheStore implements RateLimitStore
      */
     public function set(string $key, string $value, int $ttl): bool
     {
-        return $this->store->put($key, $value, $ttl);
+        $result = $this->store->put($key, $value, $ttl);
+
+        // If the data already exists in the cache, then mysql returns 0 rows affected. Technically, this is not a
+        // failure. We should check for this before returning anything and return true if it does exist.
+        if ($result === false) {
+            $existingValue = $this->store->get($key);
+            if ($existingValue === $value) {
+                return true;
+            }
+        }
+
+        return $result;
     }
 }

--- a/tests/Laravel/Feature/LaravelStoreTest.php
+++ b/tests/Laravel/Feature/LaravelStoreTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use Illuminate\Contracts\Cache\Repository;
 use Saloon\RateLimitPlugin\Limit;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Contracts\Cache\Repository;
 use Saloon\RateLimitPlugin\Stores\LaravelCacheStore;
 
 test('it records and can check exceeded limits', function () {

--- a/tests/Laravel/Feature/LaravelStoreTest.php
+++ b/tests/Laravel/Feature/LaravelStoreTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Contracts\Cache\Repository;
 use Saloon\RateLimitPlugin\Limit;
 use Illuminate\Support\Facades\Cache;
 use Saloon\RateLimitPlugin\Stores\LaravelCacheStore;
@@ -36,4 +37,18 @@ test('it records and can check exceeded limits', function () {
         'timestamp' => $timestamp + 60,
         'hits' => 1,
     ]));
+});
+
+test('it handles MySQL upsert behavior returning false for identical data', function () {
+    $mockCache = Mockery::mock(Repository::class);
+
+    $key = 'test:limit';
+    $value = json_encode(['timestamp' => time() + 60, 'hits' => 1]);
+
+    $mockCache->shouldReceive('put')->with($key, $value, Mockery::any())->andReturn(false);
+    $mockCache->shouldReceive('get')->with($key)->andReturn($value);
+
+    $store = new LaravelCacheStore($mockCache);
+
+    expect($store->set($key, $value, 60))->toBeTrue();
 });


### PR DESCRIPTION
Fixes #21 

This PR fixes an issue when using the Laravel cache store which would prevent the limit from being updated for applications using `mysql`. This is happening because if the data already exists in the store, nothing changes and mysql reports 0 rows were updated, this plugin was then treating that as not successful and would then throw a `LimitException`. 

Before
<img width="412" height="126" alt="Screenshot 2025-11-24 at 19 00 14" src="https://github.com/user-attachments/assets/50f01f4c-9fd3-4237-93f9-d405c7e373d6" />

After
<img width="412" height="126" alt="Screenshot 2025-11-24 at 19 01 52" src="https://github.com/user-attachments/assets/93236993-93d3-46e0-8694-6adf93605f89" />
