### PR TITLE
add `untilEndOfMinute` and `untilEndOfHour` intervals

### DIFF
--- a/src/Traits/HasIntervals.php
+++ b/src/Traits/HasIntervals.php
@@ -152,6 +152,38 @@ trait HasIntervals
         );
     }
 
+    public function untilEndOfMinute(): static
+    {
+        $now = new DateTimeImmutable;
+
+        $endOfMinuteTimestamp = $now->setTime(
+            (int) $now->format('H'),
+            (int) $now->format('i'),
+            59,
+        )->getTimestamp();
+
+        return $this->everySeconds(
+            seconds: $endOfMinuteTimestamp - $this->getCurrentTimestamp(),
+            timeToLiveKey: 'end_of_minute'
+        );
+    }
+
+    public function untilEndOfHour(): static
+    {
+        $now = new DateTimeImmutable;
+
+        $endOfHourTimestamp = $now->setTime(
+            (int) $now->format('H'),
+            59,
+            59,
+        )->getTimestamp();
+
+        return $this->everySeconds(
+            seconds: $endOfHourTimestamp - $this->getCurrentTimestamp(),
+            timeToLiveKey: 'end_of_hour'
+        );
+    }
+
     /**
      * Get the current timestamp
      */

--- a/tests/Unit/LimitTest.php
+++ b/tests/Unit/LimitTest.php
@@ -68,3 +68,35 @@ test('you can get the remaining seconds left on the limiter', function () {
 
     expect($limit->getRemainingSeconds())->toEqual(60);
 });
+
+test('you can create a limiter until end of minute', function () {
+    $now = new DateTimeImmutable;
+
+    $endOfMinuteTimestamp = $now->setTime(
+        (int) $now->format('H'),
+        (int) $now->format('i'),
+        59,
+    )->getTimestamp();
+
+    $seconds = $endOfMinuteTimestamp - (new DateTimeImmutable)->getTimestamp();
+
+    $limit = Limit::allow(10)->untilEndOfMinute();
+
+    expect($limit->getReleaseInSeconds())->toEqual($seconds);
+});
+
+test('you can create a limiter until end of hour', function () {
+    $now = new DateTimeImmutable;
+
+    $endOfHourTimestamp = $now->setTime(
+        (int) $now->format('H'),
+        59,
+        59,
+    )->getTimestamp();
+
+    $seconds = $endOfHourTimestamp - (new DateTimeImmutable)->getTimestamp();
+
+    $limit = Limit::allow(10)->untilEndOfHour();
+
+    expect($limit->getReleaseInSeconds())->toEqual($seconds);
+});


### PR DESCRIPTION
Adds 2 new intervals:

- `untilEndOfMinute`
- `untilEndOfHour`

Requested as part of https://github.com/saloonphp/rate-limit-plugin/issues/12, I believe these make sense to add! 