### PR TITLE
Change Memory Store to `static`

### DIFF
--- a/src/Stores/MemoryStore.php
+++ b/src/Stores/MemoryStore.php
@@ -13,14 +13,14 @@ class MemoryStore implements RateLimitStore
      *
      * @var array<string, mixed>
      */
-    protected array $store = [];
+    protected static array $store = [];
 
     /**
      * Get a rate limit from the store
      */
     public function get(string $key): ?string
     {
-        return $this->store[$key] ?? null;
+        return self::$store[$key] ?? null;
     }
 
     /**
@@ -28,7 +28,7 @@ class MemoryStore implements RateLimitStore
      */
     public function set(string $key, string $value, int $ttl): bool
     {
-        $this->store[$key] = $value;
+        self::$store[$key] = $value;
 
         return true;
     }
@@ -40,6 +40,6 @@ class MemoryStore implements RateLimitStore
      */
     public function getStore(): array
     {
-        return $this->store;
+        return self::$store;
     }
 }

--- a/src/Stores/MemoryStore.php
+++ b/src/Stores/MemoryStore.php
@@ -42,4 +42,12 @@ class MemoryStore implements RateLimitStore
     {
         return self::$store;
     }
+
+    /**
+     * Clear the store
+     */
+    public static function clear(): void
+    {
+        self::$store = [];
+    }
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 |
 */
 
-use Orchestra\Testbench\TestCase as LaravelTestCase;
 use Saloon\RateLimitPlugin\Stores\MemoryStore;
+use Orchestra\Testbench\TestCase as LaravelTestCase;
 
 uses(LaravelTestCase::class)
     ->beforeEach(fn () => MemoryStore::clear())

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -14,8 +14,16 @@ declare(strict_types=1);
 */
 
 use Orchestra\Testbench\TestCase as LaravelTestCase;
+use Saloon\RateLimitPlugin\Stores\MemoryStore;
 
-uses(LaravelTestCase::class)->in('./Laravel');
+uses(LaravelTestCase::class)
+    ->beforeEach(fn () => MemoryStore::clear())
+    ->in('./Laravel');
+
+uses()
+    ->beforeEach(fn () => MemoryStore::clear())
+    ->afterEach(fn () => MemoryStore::clear())
+    ->in('./');
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
Fixes https://github.com/saloonphp/saloon/issues/392

This PR fixes a bug with the Memory Store which was causing all requests that run through it, to have their own store which was then causing rate limits to not work correctly. If you execute 50 requests, for example, then each of them creates a new `MemoryStore` instance. 

The `HasRateLimits` trait caches the store per request:
```php
public function rateLimitStore(): RateLimitStore
{
    return $this->rateLimitStore ??= $this->resolveRateLimitStore();
}
```

But when you do `return new MemoryStore;`, each request instance gets a different `MemoryStore` object, each with its own isolated $store array and because of this, they can't share the rate limit.

The solution is to change `$store` to a `static` property so all instances share the same storage. This makes the rate limit work across multiple request instances. 

You can see below the rate limit code I had in my connector and then a before and after of my results running the exact same test:

```php
protected function resolveLimits(): array
{
    return [
        Limit::allow(1)->everySeconds(1)->sleep()
    ];
}

protected function resolveRateLimitStore(): RateLimitStore
{
    return new MemoryStore;
}
```

| Before | After |
|:-------|:-------|
| <img width="374" height="189" alt="Screenshot 2025-12-02 at 21 02 19" src="https://github.com/user-attachments/assets/33409e4d-a375-4e44-a0ba-aa4e1977aaeb" /> | <img width="374" height="189" alt="Screenshot 2025-12-02 at 21 04 21" src="https://github.com/user-attachments/assets/6df996ca-c6dd-4d6d-8d79-38035cc1c70d" /> | 

