### PR TITLE
Fix exceeded() to fall back to configured interval when Retry-After is missing

### DIFF
--- a/src/Limit.php
+++ b/src/Limit.php
@@ -130,8 +130,10 @@ class Limit
 
         $this->hits = $this->allow;
 
-        if (isset($releaseInSeconds)) {
-            $interval = DateInterval::createFromDateString($releaseInSeconds . ' seconds');
+        $seconds = $releaseInSeconds ?? $this->releaseInSeconds;
+
+        if ($seconds > 0) {
+            $interval = DateInterval::createFromDateString($seconds . ' seconds');
 
             if ($interval === false) {
                 return;

--- a/tests/Feature/HasRateLimitsTest.php
+++ b/tests/Feature/HasRateLimitsTest.php
@@ -51,12 +51,12 @@ test('when making a request with the HasRateLimits trait added it will record th
     expect($storeData)->toHaveKey('TestConnector:3_every_60');
     expect($storeData)->toHaveKey('TestConnector:too_many_attempts_limit');
 
-    expect(parseRawLimit($storeData['TestConnector:3_every_60']))->toEqual([
+    expect(parseRawLimit($storeData['TestConnector:3_every_60']))->toLookLike([
         'hits' => 1,
         'timestamp' => $currentTimestampPlusSixty,
     ]);
 
-    expect(parseRawLimit($storeData['TestConnector:too_many_attempts_limit']))->toEqual([
+    expect(parseRawLimit($storeData['TestConnector:too_many_attempts_limit']))->toLookLike([
         'hits' => 0,
         'allow' => 1,
         'timestamp' => $currentTimestampPlusSixty,
@@ -69,12 +69,12 @@ test('when making a request with the HasRateLimits trait added it will record th
 
     $storeData = $store->getStore();
 
-    expect(parseRawLimit($storeData['TestConnector:3_every_60']))->toEqual([
+    expect(parseRawLimit($storeData['TestConnector:3_every_60']))->toLookLike([
         'hits' => 2,
         'timestamp' => $currentTimestampPlusSixty,
     ]);
 
-    expect(parseRawLimit($storeData['TestConnector:too_many_attempts_limit']))->toEqual([
+    expect(parseRawLimit($storeData['TestConnector:too_many_attempts_limit']))->toLookLike([
         'hits' => 0,
         'allow' => 1,
         'timestamp' => $currentTimestampPlusSixty,
@@ -87,12 +87,12 @@ test('when making a request with the HasRateLimits trait added it will record th
 
     $storeData = $store->getStore();
 
-    expect(parseRawLimit($storeData['TestConnector:3_every_60']))->toEqual([
+    expect(parseRawLimit($storeData['TestConnector:3_every_60']))->toLookLike([
         'hits' => 3,
         'timestamp' => $currentTimestampPlusSixty,
     ]);
 
-    expect(parseRawLimit($storeData['TestConnector:too_many_attempts_limit']))->toEqual([
+    expect(parseRawLimit($storeData['TestConnector:too_many_attempts_limit']))->toLookLike([
         'hits' => 0,
         'allow' => 1,
         'timestamp' => $currentTimestampPlusSixty,
@@ -145,7 +145,7 @@ test('when making a request with the HasRateLimits trait added it will record th
     expect($storeData)->toHaveKey('TestConnector:3_every_5');
     expect($storeData)->toHaveKey('TestConnector:too_many_attempts_limit');
 
-    expect(parseRawLimit($storeData['TestConnector:3_every_5']))->toEqual([
+    expect(parseRawLimit($storeData['TestConnector:3_every_5']))->toLookLike([
         'hits' => 1,
         'timestamp' => $currentTimestampPlusFive,
     ]);
@@ -157,7 +157,7 @@ test('when making a request with the HasRateLimits trait added it will record th
 
     $storeData = $store->getStore();
 
-    expect(parseRawLimit($storeData['TestConnector:3_every_5']))->toEqual([
+    expect(parseRawLimit($storeData['TestConnector:3_every_5']))->toLookLike([
         'hits' => 2,
         'timestamp' => $currentTimestampPlusFive,
     ]);
@@ -169,7 +169,7 @@ test('when making a request with the HasRateLimits trait added it will record th
 
     $storeData = $store->getStore();
 
-    expect(parseRawLimit($storeData['TestConnector:3_every_5']))->toEqual([
+    expect(parseRawLimit($storeData['TestConnector:3_every_5']))->toLookLike([
         'hits' => 3,
         'timestamp' => $currentTimestampPlusFive,
     ]);
@@ -344,12 +344,12 @@ test('the rate limiter can be used on a request', function () {
     expect($storeData)->toHaveKey('LimitedRequest:60_every_60');
     expect($storeData)->toHaveKey('LimitedRequest:too_many_attempts_limit');
 
-    expect(parseRawLimit($storeData['LimitedRequest:60_every_60']))->toEqual([
+    expect(parseRawLimit($storeData['LimitedRequest:60_every_60']))->toLookLike([
         'hits' => 1,
         'timestamp' => $currentTimestampPlusSixty,
     ]);
 
-    expect(parseRawLimit($storeData['LimitedRequest:too_many_attempts_limit']))->toEqual([
+    expect(parseRawLimit($storeData['LimitedRequest:too_many_attempts_limit']))->toLookLike([
         'hits' => 0,
         'allow' => 1,
         'timestamp' => $currentTimestampPlusSixty,
@@ -390,23 +390,23 @@ test('when the the rate limiter is used on both the connector or request all the
     expect($storeData)->toHaveKey('TestConnector:3_every_60');
     expect($storeData)->toHaveKey('TestConnector:too_many_attempts_limit');
 
-    expect(parseRawLimit($storeData['TestConnector:3_every_60']))->toEqual([
+    expect(parseRawLimit($storeData['TestConnector:3_every_60']))->toLookLike([
         'hits' => 1,
         'timestamp' => $currentTimestampPlusSixty,
     ]);
 
-    expect(parseRawLimit($storeData['TestConnector:too_many_attempts_limit']))->toEqual([
+    expect(parseRawLimit($storeData['TestConnector:too_many_attempts_limit']))->toLookLike([
         'hits' => 0,
         'allow' => 1,
         'timestamp' => $currentTimestampPlusSixty,
     ]);
 
-    expect(parseRawLimit($storeData['LimitedRequest:60_every_60']))->toEqual([
+    expect(parseRawLimit($storeData['LimitedRequest:60_every_60']))->toLookLike([
         'hits' => 1,
         'timestamp' => $currentTimestampPlusSixty,
     ]);
 
-    expect(parseRawLimit($storeData['LimitedRequest:too_many_attempts_limit']))->toEqual([
+    expect(parseRawLimit($storeData['LimitedRequest:too_many_attempts_limit']))->toLookLike([
         'hits' => 0,
         'allow' => 1,
         'timestamp' => $currentTimestampPlusSixty,
@@ -443,12 +443,12 @@ test('the rate limiter can be used on a solo request', function () {
     expect($storeData)->toHaveKey('LimitedSoloRequest:60_every_60');
     expect($storeData)->toHaveKey('LimitedSoloRequest:too_many_attempts_limit');
 
-    expect(parseRawLimit($storeData['LimitedSoloRequest:60_every_60']))->toEqual([
+    expect(parseRawLimit($storeData['LimitedSoloRequest:60_every_60']))->toLookLike([
         'hits' => 1,
         'timestamp' => $currentTimestampPlusSixty,
     ]);
 
-    expect(parseRawLimit($storeData['LimitedSoloRequest:too_many_attempts_limit']))->toEqual([
+    expect(parseRawLimit($storeData['LimitedSoloRequest:too_many_attempts_limit']))->toLookLike([
         'hits' => 0,
         'allow' => 1,
         'timestamp' => $currentTimestampPlusSixty,

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -44,6 +44,22 @@ function parseRawLimit(?string $data): ?array
     return ! empty($data) ? json_decode($data, true) : null;
 }
 
+expect()->extend('toLookLike', function (array $expected) {
+    $actual = $this->value;
+
+    $expectedTimestamp = $expected['timestamp'];
+    unset($expected['timestamp']);
+
+    $actualTimestamp = $actual['timestamp'];
+    unset($actual['timestamp']);
+
+    expect($actual)->toEqual($expected);
+    expect($actualTimestamp)->toBeGreaterThanOrEqual($expectedTimestamp);
+    expect($actualTimestamp)->toBeLessThanOrEqual($expectedTimestamp + 1);
+
+    return $this;
+});
+
 /**
  * Reset the testing directory
  */

--- a/tests/Unit/LimitTest.php
+++ b/tests/Unit/LimitTest.php
@@ -100,3 +100,31 @@ test('you can create a limiter until end of hour', function () {
 
     expect($limit->getReleaseInSeconds())->toEqual($seconds);
 });
+
+test('exceeded without releaseInSeconds falls back to the configured interval', function () {
+    $limit = Limit::allow(10)->everySeconds(120);
+
+    $limit->exceeded();
+
+    expect($limit->wasManuallyExceeded())->toBeTrue()
+        ->and($limit->getHits())->toBe(10)
+        ->and($limit->getRemainingSeconds())->toBe(120);
+});
+
+test('exceeded with explicit releaseInSeconds uses the provided value', function () {
+    $limit = Limit::allow(10)->everySeconds(120);
+
+    $limit->exceeded(releaseInSeconds: 300);
+
+    expect($limit->wasManuallyExceeded())->toBeTrue()
+        ->and($limit->getRemainingSeconds())->toBe(300);
+});
+
+test('custom limiter exceeded without releaseInSeconds falls back to default 60 seconds', function () {
+    $limit = Limit::custom(function () {});
+
+    $limit->exceeded();
+
+    expect($limit->wasManuallyExceeded())->toBeTrue()
+        ->and($limit->getRemainingSeconds())->toBe(60);
+});

--- a/tests/Unit/LimitTest.php
+++ b/tests/Unit/LimitTest.php
@@ -121,7 +121,8 @@ test('exceeded with explicit releaseInSeconds uses the provided value', function
 });
 
 test('custom limiter exceeded without releaseInSeconds falls back to default 60 seconds', function () {
-    $limit = Limit::custom(function () {});
+    $limit = Limit::custom(function () {
+    });
 
     $limit->exceeded();
 


### PR DESCRIPTION
## Summary

When `Limit::exceeded()` is called without a `releaseInSeconds` value (e.g. when a 429 response has no `Retry-After` header), the `expiryTimestamp` was not set explicitly. This caused it to be lazily recalculated from "now" on each call to `getExpiryTimestamp()`, which can drift and produce inconsistent state depending on when it's accessed.

This change makes `exceeded()` fall back to the limit's configured `releaseInSeconds` interval when no explicit value is provided, ensuring the expiry timestamp is always set deterministically at the moment the limit is exceeded.

### Before

```php
// Retry-After header missing → releaseInSeconds is null
$limit->exceeded(releaseInSeconds: null);

// expiryTimestamp is NOT set — lazy calculation from "now" on each access
$limit->getExpiryTimestamp(); // recalculates each time
```

### After

```php
// Retry-After header missing → releaseInSeconds is null
$limit->exceeded(releaseInSeconds: null);

// Falls back to the limit's configured interval (e.g. 60s for custom limiters)
// expiryTimestamp is set once, deterministically
$limit->getExpiryTimestamp(); // stable value
```

## Changes

- **`src/Limit.php`**: In `exceeded()`, fall back to `$this->releaseInSeconds` when `$releaseInSeconds` is null
- **`tests/Unit/LimitTest.php`**: Added 3 tests covering the fallback behavior for regular limits, explicit values, and custom limiters
- **`tests/Pest.php`**: Added `toLookLike` custom Pest expectation that tolerates ±1 second timestamp drift
- **`tests/Feature/HasRateLimitsTest.php`**: Replaced exact timestamp assertions with `toLookLike` to fix flaky CI failures on slow runners

## Test plan

- [x] All existing tests pass (84 passed, 0 failures)
- [x] New tests verify fallback to configured interval when `releaseInSeconds` is null
- [x] New tests verify explicit `releaseInSeconds` still takes precedence
- [x] New tests verify `Limit::custom()` defaults to 60s fallback
- [x] Flaky timestamp assertion on Windows CI fixed with tolerant `toLookLike` expectation