### PR TITLE
Fix | Retry via connector when rate limit sleep follows manual exceed

### DIFF
--- a/src/Traits/HasRateLimits.php
+++ b/src/Traits/HasRateLimits.php
@@ -92,15 +92,18 @@ trait HasRateLimits
             // place. We should make sure to throw the exception here.
 
             if (isset($limitThatWasExceeded)) {
-                if (! $limit->getShouldSleep()) {
+                if (! $limitThatWasExceeded->getShouldSleep()) {
                     $this->throwLimitException($limitThatWasExceeded);
                 }
 
                 // When the limit has been instructed to sleep() we will make the request
                 // again, which will trigger the request middleware to sleep, and then
                 // hopefully get a successful response afterward.
+                //
+                // Always delegate to the connector: send() exists on Connector but not on Request
+                // (see saloonphp/saloon#532).
 
-                return $this->send($response->getRequest());
+                return $response->getConnector()->send($response->getRequest());
             }
 
             return $response;


### PR DESCRIPTION
Fixes https://github.com/saloonphp/saloon/issues/532

When `HasRateLimits` is applied to a Request (not a Connector), a 429 handled with `getTooManyAttemptsLimiter()->sleep()` triggers a retry that called `$this->send()`. `send()` exists on Connector, not Request, so the retry fails (e.g. BadMethodCallException via Macroable, or an undefined-method error depending on context).

This PR introduces some changes:

Retry using `$response->getConnector()->send($response->getRequest())` so the retry always goes through the connector.
Use `$limitThatWasExceeded->getShouldSleep()` instead of the loop’s last `$limit` when deciding whether to throw vs sleep/retry.